### PR TITLE
Oppdaterer avhengigheter.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val dusseldorfKtorVersion = "1.5.2.1303b90"
 val k9FormatVersion = "5.1.38"
-val openhtmltopdfVersion = "1.0.6"
-val handlebarsVersion = "4.1.2"
+val openhtmltopdfVersion = "1.0.8"
+val handlebarsVersion = "4.2.0"
 
 val ktorVersion = ext.get("ktorVersion").toString()
 val slf4jVersion = ext.get("slf4jVersion").toString()
@@ -15,7 +15,7 @@ val kafkaVersion = ext.get("kafkaVersion").toString() // Alligned med version fr
 val mainClass = "no.nav.helse.OmsorgspengerutbetalingeSoknadProsesseringKt"
 
 plugins {
-    kotlin("jvm") version "1.4.32"
+    kotlin("jvm") version "1.5.10"
     id("com.github.johnrengelman.shadow") version "6.1.0"
 }
 
@@ -98,5 +98,5 @@ tasks.withType<ShadowJar> {
 }
 
 tasks.withType<Wrapper> {
-    gradleVersion = "6.8.3"
+    gradleVersion = "7.0.2"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -10,6 +10,7 @@ import java.net.URI
 import java.time.Duration
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
+import java.util.*
 
 @KtorExperimentalAPI
 data class Configuration(private val config : ApplicationConfig) {


### PR DESCRIPTION
Closes #63
Closes #56
Closes #46

Sliter med å oppdatere johnrengelman.shadow til 7. Klager på at jeg må oppdatere Gradle til 7, men det har jeg gjort.. 
"An exception occurred applying plugin request [id: 'com.github.johnrengelman.shadow', version: '7.0.0']
> Failed to apply plugin class 'com.github.jengelman.gradle.plugins.shadow.ShadowBasePlugin'.
   > This version of Shadow supports Gradle 7.0+ only. Please upgrade."