### PR TITLE
Oppdaterer til nyeste dusseldorf-ktor.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val dusseldorfKtorVersion = "1.5.2.1303b90"
+val dusseldorfKtorVersion = "1.5.4.ae44e47"
 val k9FormatVersion = "5.1.38"
 val openhtmltopdfVersion = "1.0.8"
 val handlebarsVersion = "4.2.0"
@@ -21,7 +21,7 @@ plugins {
 
 buildscript {
     // Henter ut diverse dependency versjoner, i.e. ktorVersion.
-    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/1303b90c37ad3d94905c6eb7f6b47b6312d19aba/gradle/dusseldorf-ktor.gradle.kts")
+    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/ae44e47780062c9aa349cb88e14546b01325642f/gradle/dusseldorf-ktor.gradle.kts")
 }
 
 dependencies {

--- a/src/main/kotlin/no/nav/helse/prosessering/Metadata.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/Metadata.kt
@@ -2,6 +2,5 @@ package no.nav.helse.prosessering
 
 data class Metadata(
     val version : Int,
-    val correlationId : String,
-    val requestId : String
+    val correlationId : String
 )

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topology.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/Topology.kt
@@ -23,7 +23,6 @@ internal fun <BEFORE, AFTER>process(
     block: suspend() -> AFTER) : TopicEntry<AFTER> {
     return runBlocking(MDCContext(mapOf(
         "correlation_id" to entry.metadata.correlationId,
-        "request_id" to entry.metadata.requestId,
         "soknad_id" to soknadId
     ))) {
         val processed = try {

--- a/src/test/kotlin/no/nav/helse/KafkaWrapper.kt
+++ b/src/test/kotlin/no/nav/helse/KafkaWrapper.kt
@@ -140,8 +140,7 @@ fun KafkaProducer<String, TopicEntry<MeldingV1>>.leggTilMottak(soknad: MeldingV1
             TopicEntry(
                 metadata = Metadata(
                     version = 1,
-                    correlationId = UUID.randomUUID().toString(),
-                    requestId = UUID.randomUUID().toString()
+                    correlationId = UUID.randomUUID().toString()
                 ),
                 data = soknad
             )


### PR DESCRIPTION
Fjerner requestId fra metadata for å kunne oppdatere mottak til nyeste dusseldorf-ktor hvor det feltet er fjernet.